### PR TITLE
Update search terms to Waymo/Tesla and current service cities

### DIFF
--- a/src/config/search-terms.ts
+++ b/src/config/search-terms.ts
@@ -1,70 +1,51 @@
 // Target subreddits for robotaxi content
 export const TARGET_SUBREDDITS = [
-  // Robotaxi-specific
+  // Company-specific
   'Waymo',
-  'robotaxi',
-  'SelfDrivingCars',
-
-  // Tesla communities
   'TeslaMotors',
   'TeslaLounge',
-  'electricvehicles',
+  'TeslaFSD',
 
-  // Operating area cities (high priority)
-  'sanfrancisco',
-  'bayarea',
-  'Phoenix',
+  // Service cities
   'Austin',
+  'Atlanta',
   'LosAngeles',
+  'Phoenix',
 
-  // Secondary cities
+  // Bay Area cities (general subreddits)
+  'bayarea',
+  'sanfrancisco',
+  'Oakland',
   'SanJose',
+  'berkeley',
+  'DalyCity',
+  'SanMateo',
+  'RedwoodCity',
+  'Fremont',
+  'Sunnyvale',
   'MountainView',
   'PaloAlto',
-  'SantaMonica',
-  'Scottsdale',
-
-  // Expansion cities
-  'Atlanta',
-  'Denver',
-  'Seattle',
-  'Miami',
-  'Dallas',
-
-  // Tech subreddits
-  'technology',
-  'Futurology',
-  'cars',
-  'Autos',
-
-  // Competitor awareness
-  'Cruise',
-  'Zoox',
-  'Aurora',
+  'MenloPark',
+  'LosAltos',
 ] as const
 
 // Robotaxi-specific subreddits (skip keyword filtering for these)
 export const ROBOTAXI_SUBREDDITS = new Set([
   'Waymo',
-  'robotaxi',
-  'SelfDrivingCars',
-  'Cruise',
-  'Zoox',
-  'Aurora',
+  'TeslaFSD',
 ])
 
 // Keywords that strongly indicate robotaxi content
 export const ROBOTAXI_KEYWORDS = [
-  'robotaxi',
   'waymo',
-  'cybercab',
-  'autonomous taxi',
-  'self driving',
-  'driverless',
-  'fsd',
-  'robo taxi',
-  'autonomous vehicle',
-  'self-driving',
   'waymo one',
-  'driverless taxi',
+  'tesla',
+  'tesla robotaxi',
+  'tesla robo taxi',
+  'cybercab',
+  'fsd',
+  'full self driving',
+  'full self-driving',
+  'autopilot',
+  'tesla autonomy',
 ] as const


### PR DESCRIPTION
## Summary
- Focus search scope on Waymo and Tesla communities only
- Limit city subreddits to current service areas (Austin, Atlanta, LA, Phoenix, Bay Area cities)
- Tighten robotaxi keywords to Waymo/Tesla-specific terms

## Changes
- Updated `src/config/search-terms.ts` to remove competitor/expansion subreddits
- Added targeted Bay Area city subreddits for local coverage
- Updated `ROBOTAXI_SUBREDDITS` and keyword list to align with Waymo/Tesla

## Testing
- Not run (config-only change)
